### PR TITLE
Add Ecommerce Profit Tracker PRO to Analytics & Profit Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Understand your true profit after all Amazon fees, PPC costs, and COGS.
 - [Nozzle](https://nozzle.ai/) — Amazon analytics focused on ad performance, profitability, and market share.
 - [NovaData](https://www.novadata.io/) — Near real-time profit tracking and advertising analytics.
 - [ManageByStats](https://managebystats.com/) — Comprehensive seller analytics, customer management, and profit tracking.
+- [Ecommerce Profit Tracker PRO](https://limin6661.github.io/ecommerce-profit-tracker/) — Excel & Google Sheets template for tracking true profit per order after platform fees, ads, shipping, COGS, and refunds. One-time $19, no subscription. Works for Etsy, Shopify, Amazon, eBay.
 
 ## Reimbursements & Refunds
 


### PR DESCRIPTION
## What

Adds **Ecommerce Profit Tracker PRO** to the **Analytics & Profit Tracking** section.

## Why it fits

It belongs in this section — it's a profit-tracking tool that calculates the true profit per order after platform fees, ad spend, shipping, COGS, and refunds. While most entries here are Amazon-specific SaaS dashboards, this one is a no-subscription Excel/Google Sheets alternative that covers **Etsy, Shopify, Amazon, eBay, and WooCommerce** in a single workbook — useful for sellers who run multiple marketplaces or want an offline, one-time-cost option alongside Sellerboard/HelloProfit.

## Details

- One-time **$19**, no subscription (counterpoint to the recurring SaaS fees on the existing entries)
- Pure formulas, no macros — opens cleanly in Excel and Google Sheets
- Live demo + features: https://limin6661.github.io/ecommerce-profit-tracker/

I built and use this tool myself. Happy to adjust the entry wording or category if a maintainer prefers it elsewhere. Thanks for curating this list!